### PR TITLE
#67 [FEAT] 투두 수정 뷰에서 TextField 바깥 영역 탭하면 수정 종료

### DIFF
--- a/picle/lib/widgets/list/todo_item.dart
+++ b/picle/lib/widgets/list/todo_item.dart
@@ -22,7 +22,6 @@ class TodoItem extends StatefulWidget {
 
 class _TodoItemState extends State<TodoItem> {
   final TextEditingController _controller = TextEditingController();
-  FocusNode textFocus = FocusNode();
   late String content;
   late bool isUpdate;
 
@@ -37,7 +36,6 @@ class _TodoItemState extends State<TodoItem> {
   @override
   void dispose() {
     _controller.dispose();
-    textFocus.dispose();
     super.dispose();
   }
 
@@ -89,7 +87,6 @@ class _TodoItemState extends State<TodoItem> {
             Expanded(
               child: TextField(
                 controller: _controller,
-                focusNode: textFocus,
                 autofocus: true,
                 decoration: const InputDecoration(
                   hintText: '수정할 내용을 입력해주세요.',
@@ -102,6 +99,13 @@ class _TodoItemState extends State<TodoItem> {
                     borderSide: BorderSide(color: Color(0xFF54C29B), width: 2),
                   ),
                 ),
+                onTapOutside: (event) {
+                  _controller.text = widget.text;
+                  FocusManager.instance.primaryFocus?.unfocus();
+                  setState(() {
+                    isUpdate = false;
+                  });
+                },
                 onChanged: (text) {
                   setState(() {
                     content = text;


### PR DESCRIPTION
## 📍Issue Number or Link
- closed #67 
</br>

## 🫧Description
투두 수정 중 TextField 바깥 영역 탭하면 수정 종료.

</br>

## ✨PR Type
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✔️PR Checklist
PR이 다음 요구 사항을 충족하는 지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/Team-Picle/Picle-Client)  (Ctrl + 클릭하세요.)
