### PR TITLE
#87 [STYLE] 캘린더 주말 데이터의 텍스트 컬러를 브랜드 컬러로 수정 & 주말의 위치 변경

### DIFF
--- a/picle/lib/widgets/calender.dart
+++ b/picle/lib/widgets/calender.dart
@@ -24,7 +24,7 @@ class _CalendarState extends State<Calendar> {
       firstDay: DateTime.utc(2010, 10, 16),
       lastDay: DateTime.utc(2030, 3, 14),
       focusedDay: _focusedDay,
-      startingDayOfWeek: StartingDayOfWeek.monday,
+      startingDayOfWeek: StartingDayOfWeek.sunday,
       availableCalendarFormats: const {
         CalendarFormat.month: 'Month',
         CalendarFormat.week: 'Week'
@@ -65,9 +65,9 @@ class _CalendarState extends State<Calendar> {
             const Icon(Icons.chevron_right, color: Color(0XFF54C29B)),
       ),
       calendarStyle: const CalendarStyle(
-        weekendTextStyle: TextStyle(color: Colors.red),
+        weekendTextStyle: TextStyle(color: Color(0XFF54C29B)),
         weekNumberTextStyle: TextStyle(
-          color: Colors.red,
+          color: Color(0XFF54C29B),
           fontSize: 12,
         ),
       ),
@@ -79,7 +79,7 @@ class _CalendarState extends State<Calendar> {
               child: Text(
                 day.weekday == DateTime.sunday ? '일' : '토',
                 style: const TextStyle(
-                  color: Colors.red,
+                  color: Color(0XFF54C29B),
                 ),
               ),
             );


### PR DESCRIPTION
## 📍Issue Number or Link
- closed #87
</br>

## 🫧Description
- 캘린더 주말 데이터의 텍스트 컬러를 브랜드 컬러로 수정
- 주말의 위치 변경

</br>

## ✨PR Type
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✔️PR Checklist
PR이 다음 요구 사항을 충족하는 지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/Team-Picle/Picle-Client)  (Ctrl + 클릭하세요.)
