### PR TITLE
#128 [FIX] time이 null일 때는 request에서 제외

### DIFF
--- a/picle/lib/providers/routine_provider.dart
+++ b/picle/lib/providers/routine_provider.dart
@@ -164,7 +164,7 @@ class RoutineProvider extends ChangeNotifier {
       final jsonData = {
         'content': content,
         'registrationImgUrl': imgUrl,
-        'time': time,
+        if (time != null) 'time': time,
         'startRepeatDate': startRepeatDate,
         'repeatDays': repeatDays,
         'destinationLongitude': destinationLongitude,
@@ -177,6 +177,8 @@ class RoutineProvider extends ChangeNotifier {
         headers: {'Content-Type': 'application/json'},
       );
       final responseBody = jsonDecode(utf8.decode(response.bodyBytes));
+
+      print(responseBody);
 
       if (responseBody['data'] != null) {
         await fetchPreviewList(date);
@@ -327,6 +329,9 @@ class RoutineProvider extends ChangeNotifier {
     repeatDays,
     date,
   }) async {
+    print('time: $time');
+    print('repeatDays: $repeatDays');
+
     try {
       final uri = Uri.http(
           serverEndpoint, apiPath['updatePreview']!(userId, routineId));

--- a/picle/lib/widgets/list/routine_list.dart
+++ b/picle/lib/widgets/list/routine_list.dart
@@ -161,7 +161,6 @@ Future<void> addBottomModal({
         }
 
         Widget renderAddImg() {
-          print(destinationPicked);
           return Column(
             children: [
               GestureDetector(
@@ -832,6 +831,8 @@ class _RenderAddDateState extends State<RenderAddDate> {
             timePicked = false;
             selectedTime = null;
             DateTime? pickedTime = await showTimePickerModal(context);
+
+            print(pickedTime);
 
             if (pickedTime != null) {
               setState(() {


### PR DESCRIPTION
## 📍Issue Number or Link
- closed #128 
</br>

## 🫧Description
루틴 등록 모달에서 time 지정을 안 하면 기본값으로 null이 전달되는데, time은 `String` 타입이기 때문에 타입 에러 발생.
time이 null일 땐 request에서 제외하도록 수정.

</br>

## ✨PR Type
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✔️PR Checklist
PR이 다음 요구 사항을 충족하는 지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/Team-Picle/Picle-Client)  (Ctrl + 클릭하세요.)
