### PR TITLE
#132 [FIX] 투두 추가 후 TextField의 _controller.text를 빈 문자열로 초기화

### DIFF
--- a/picle/lib/widgets/list/todo_list.dart
+++ b/picle/lib/widgets/list/todo_list.dart
@@ -75,6 +75,7 @@ class _TodoListState extends State<TodoList> {
                     content: _controller.text,
                     date: date,
                   );
+              _controller.text = '';
             },
           ),
         Expanded(


### PR DESCRIPTION
## 📍Issue Number or Link
- closed #132 
</br>

## 🫧Description
투두 추가 후 TextField의 _controller.text를 빈 문자열로 초기화

</br>

## ✨PR Type
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✔️PR Checklist
PR이 다음 요구 사항을 충족하는 지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  [Commit message convention 참고](https://github.com/Team-Picle/Picle-Client)  (Ctrl + 클릭하세요.)
